### PR TITLE
Update from WordPress Develop Repository and normalize line endings

### DIFF
--- a/data/blocks/notice/variations.php
+++ b/data/blocks/notice/variations.php
@@ -1,0 +1,10 @@
+<?php
+
+return array(
+	array(
+		'name'        => 'warning',
+		'title'       => 'warning',
+		'description' => 'Shows warning.',
+		'keywords'    => array( 'warning' ),
+	),
+);

--- a/includes/testcase-rest-post-type-controller.php
+++ b/includes/testcase-rest-post-type-controller.php
@@ -107,8 +107,10 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 		// Check filtered values.
 		if ( post_type_supports( $post->post_type, 'title' ) ) {
 			add_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
+			add_filter( 'private_title_format', array( $this, 'protected_title_format' ) );
 			$this->assertSame( get_the_title( $post->ID ), $data['title']['rendered'] );
 			remove_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
+			remove_filter( 'private_title_format', array( $this, 'protected_title_format' ) );
 			if ( 'edit' === $context ) {
 				$this->assertSame( $post->post_title, $data['title']['raw'] );
 			} else {


### PR DESCRIPTION
This PR updates the codebase with the latest changes from the WordPress Develop repository and normalizes line endings.

Changes include:
- Updated files in `data/` and `includes/` directories
- Updated `multisite.xml`, `wp-mail-real-test.php`, and `wp-config-sample.php`
- Normalized line endings to LF for all files

This update was automatically generated by the GitHub Actions workflow.